### PR TITLE
Add content to control messages and style them differently

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -139,6 +139,10 @@
                         avatar     : pushMessageContent.group.avatar,
                         members    : pushMessageContent.group.members,
                     };
+                    pushMessageContent.body = source + ' added you to ' + attributes.name;
+                    message.set('control', true);
+                } else {
+                    message.set('control', false);
                 }
                 attributes.active_at = now;
                 conversation.set(attributes);

--- a/js/background.js
+++ b/js/background.js
@@ -139,8 +139,8 @@
                         avatar     : pushMessageContent.group.avatar,
                         members    : pushMessageContent.group.members,
                     };
-                    pushMessageContent.body = source + ' added you to ' + attributes.name;
                     message.set('control', true);
+                    message.set('control_message', source + ' added you to ' + attributes.name);
                 } else {
                     message.set('control', false);
                 }

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -70,11 +70,15 @@
     },
 
     render: function() {
+        var bubble_class = this.model.get('type') === 'outgoing' ? 'sent' : 'incoming';
+        if (this.model.get('control')) {
+          bubble_class += ' control';
+        }
         this.$el.html(
           Mustache.render(this.template, {
             message: this.model.get('body'),
             timestamp: moment(this.model.get('received_at')).fromNow(),
-            bubble_class: this.model.get('type') === 'outgoing' ? 'sent' : 'incoming',
+            bubble_class: bubble_class,
             sender: this.model.get('source')
           })
         );

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -71,12 +71,15 @@
 
     render: function() {
         var bubble_class = this.model.get('type') === 'outgoing' ? 'sent' : 'incoming';
+        var message = this.model.get('body');
         if (this.model.get('control')) {
           bubble_class += ' control';
+          message = this.model.get('control_message');
         }
+
         this.$el.html(
           Mustache.render(this.template, {
-            message: this.model.get('body'),
+            message: message,
             timestamp: moment(this.model.get('received_at')).fromNow(),
             bubble_class: bubble_class,
             sender: this.model.get('source')

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -230,6 +230,8 @@ ul.discussion {
     text-align: right;
     background-color: #00badd;
     color: white; }
+  .bubble.control {
+    border: 1px solid #9c9c9c; }
 
 @media screen and (min-width: 320px) {
   .send-message-area {

--- a/stylesheets/view/_conversation.scss
+++ b/stylesheets/view/_conversation.scss
@@ -73,6 +73,7 @@ ul.discussion {
     background-color:#00badd;
     color:white;
   }
-  &.sent .volley {
+  &.control {
+    border: 1px solid darken(whitesmoke, 35%);
   }
 }


### PR DESCRIPTION
![screen shot](https://cloud.githubusercontent.com/assets/801452/5558953/f776fb82-8cff-11e4-8362-8ffbab99834a.png)

I added a boolean "control" attribute to the message model. Is that the right way to go about this? I'm wondering if it should instead be an attribute describing what particular type of control message it is.