### PR TITLE
Re-enable sauce for PR's

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,13 +149,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('dev', ['connect', 'watch']);
-  //Do not run saucelabs tests on pull requests because they will fail
-  var pullRequest = process.env.TRAVIS_PULL_REQUEST;
-  if (pullRequest ==="false") {
-    grunt.registerTask('test', ['jshint', 'connect', 'saucelabs-mocha']);
-  } else {
-    grunt.registerTask('test', ['jshint']);
-  }
+  grunt.registerTask('test', ['jshint', 'connect', 'saucelabs-mocha']);
   grunt.registerTask('default', ['preen', 'concat', 'sass']);
   grunt.registerTask('build', ['compile', 'concat:curve25519']);
 


### PR DESCRIPTION
Revert "Do not run saucelabs tests on pull requests because they will fail"

This reverts commit 7b851ba548ea8ab9774b59a6adcf5e27c9254360.

This seemed like a good idea at the time, but it prevents tests from
being run on PR's made from branches within our own fork.(*) Also, in
hindsight, I find that the "merge with caution" alert banner is an
appropriate adornment for PR's which have not been able to run the
saucelabs tests due to their alien origin.

(*) Like this one