### PR TITLE
Add JSCS and run as part of grunt test task

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "disallowMixedSpacesAndTabs": true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,6 +84,11 @@ module.exports = function(grunt) {
       files: ['Gruntfile.js'],  // add 'src/**/*.js', 'test/**/*.js'
       options: { jshintrc: '.jshintrc' },
     },
+    jscs: {
+      all: {
+        src: ['js/**/*.js', '!js/components.js', 'test/**/*.js']
+      }
+    },
     watch: {
       files: ['<%= jshint.files %>'],
       tasks: ['jshint']
@@ -149,7 +154,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('dev', ['connect', 'watch']);
-  grunt.registerTask('test', ['jshint', 'connect', 'saucelabs-mocha']);
+  grunt.registerTask('test', ['jshint', 'jscs', 'connect', 'saucelabs-mocha']);
   grunt.registerTask('default', ['preen', 'concat', 'sass']);
   grunt.registerTask('build', ['compile', 'concat:curve25519']);
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-preen": "^1.0.0",
-    "grunt-saucelabs": "^8.3.3"
+    "grunt-saucelabs": "^8.3.3",
+    "grunt-jscs": "^1.1.0"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
As suggested in #109 I've added JSCS to avoid the reintroduction of tabs. I've started with the `disallowMixedSpacesAndTabs` rule, which only checks for *mixes* of spaces and tabs. Ideally, we'd also enable the `validateIndentation` rule, which checks that indentation is correct (and that spaces are used instead of tabs). Unfortunately, there are lots of violations of this rule in the code so it will require some tidying up before it can be enabled.