### PR TITLE
Return end session messages to the frontend

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -16278,7 +16278,7 @@ textsecure.processDecrypted = function(decrypted, source) {
 
     if ((decrypted.flags & textsecure.protobuf.PushMessageContent.Flags.END_SESSION)
                 == textsecure.protobuf.PushMessageContent.Flags.END_SESSION)
-        return;
+        return Promise.resolve(decrypted);
     if (decrypted.flags != 0) {
         throw new Error("Unknown flags in message");
     }

--- a/libtextsecure/helpers.js
+++ b/libtextsecure/helpers.js
@@ -163,7 +163,7 @@ textsecure.processDecrypted = function(decrypted, source) {
 
     if ((decrypted.flags & textsecure.protobuf.PushMessageContent.Flags.END_SESSION)
                 == textsecure.protobuf.PushMessageContent.Flags.END_SESSION)
-        return;
+        return Promise.resolve(decrypted);
     if (decrypted.flags != 0) {
         throw new Error("Unknown flags in message");
     }


### PR DESCRIPTION
So we can save them in the message history, and because the caller expects a promise.