### PR TITLE
Extract app-level key conflict logic from libts

### DIFF
--- a/conversation.html
+++ b/conversation.html
@@ -87,6 +87,10 @@
                 </div>
             </div>
         </script>
+        <script type='text/x-tmpl-mustache' id='key-conflict'>
+          {{ message }}
+          <button class='resolve'>Resolve</button>
+        </script>
 
         <script type="text/javascript" src="js/components.js"></script>
 
@@ -108,6 +112,7 @@
         <script type="text/javascript" src="js/views/end_session_view.js"></script>
         <script type="text/javascript" src="js/views/group_update_view.js"></script>
         <script type="text/javascript" src="js/views/attachment_view.js"></script>
+        <script type="text/javascript" src="js/views/error_view.js"></script>
         <script type="text/javascript" src="js/views/message_view.js"></script>
         <script type="text/javascript" src="js/views/message_list_view.js"></script>
 

--- a/js/background.js
+++ b/js/background.js
@@ -94,7 +94,6 @@
                         ));
                     }).catch(function(e) {
                         if (e.name === 'IncomingIdentityKeyError') {
-                            e.args.push(message.id);
                             message.save({ errors : [e] }).then(function() {
                                 extension.trigger('message', message);
                                 openConversation(conversation.id);

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -92,7 +92,7 @@
             var keyErrors = [];
             _.each(errors, function(e) {
                 if (e.error.name === 'OutgoingIdentityKeyError') {
-                    e.error.args.push(message.id);
+                    e.error.args.push(now);
                     keyErrors.push(e.error);
                 }
             });

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -40,6 +40,12 @@
         },
         isGroupUpdate: function() {
             return !!(this.get('group_update'));
+        },
+        isIncoming: function() {
+            return this.get('type') === 'incoming';
+        },
+        isOutgoing: function() {
+            return this.get('type') === 'outgoing';
         }
     });
 

--- a/js/views/error_view.js
+++ b/js/views/error_view.js
@@ -1,0 +1,102 @@
+/* vim: ts=4:sw=4:expandtab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+(function () {
+    'use strict';
+
+    window.Whisper = window.Whisper || {};
+    var ErrorTextView = Backbone.View.extend({
+        className: 'error',
+        render: function() {
+            this.$el.text(this.model.message);
+            return this;
+        }
+    });
+
+    var KeyConflictView = Backbone.View.extend({
+        className: 'key-conflict',
+        events: {
+            'click .resolve' : 'resolve'
+        },
+        initialize: function(options) {
+            this.template = $('#key-conflict').html();
+            Mustache.parse(this.template);
+            this.message = options.message;
+        },
+        resolve: function() {
+            this.undelegateEvents(); // avoid double replays
+            var replayable = new window.textsecure.ReplayableError(this.model);
+
+            if (this.message.isOutgoing()) {
+                replayable.onsuccess = function(){
+                    this.message.save('errors', []);
+                    this.onsuccess();
+                }.bind(this);
+            } else if (this.message.isIncoming()) {
+                replayable.onsuccess = function(pushMessageContent) {
+                    extension.trigger('message:decrypted', {
+                        message_id : this.message.id,
+                        data       : pushMessageContent
+                    });
+                    this.onsuccess();
+                }.bind(this);
+            }
+
+            replayable.onfailure = function(new_errors) {
+                if (!_.isArray(new_errors)) {
+                    new_errors = [new_errors];
+                }
+
+                this.message.save('errors', new_errors);
+                this.onfailure();
+            }.bind(this);
+
+            replayable.replay();
+        },
+        onfailure: function() {
+            this.delegateEvents();
+        },
+        onsuccess: function() {
+            this.remove();
+        },
+        render: function() {
+            this.$el.html(
+                Mustache.render(this.template, { message: this.model.message })
+            );
+            return this;
+        }
+    });
+
+    Whisper.MessageErrorView = Backbone.View.extend({
+        className: 'error',
+        initialize: function(options) {
+            if (this.model.name === 'IncomingIdentityKeyError' ||
+                this.model.name === 'OutgoingIdentityKeyError') {
+                this.view = new KeyConflictView({
+                    model   : this.model,
+                    message : options.message
+                });
+            } else {
+                this.view = new ErrorTextView({ model: this.model });
+            }
+            this.$el.append(this.view.el);
+            this.view.render();
+        },
+        render: function() {
+            this.view.render();
+            return this;
+        }
+    });
+})();

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -18,21 +18,6 @@
 
     window.Whisper = window.Whisper || {};
 
-    var ErrorView = Backbone.View.extend({
-        className: 'error',
-        events: {
-            'click' : 'replay'
-        },
-        replay: function() {
-            new window.textsecure.ReplayableError(this.model).replay();
-        },
-        render: function() {
-            this.$el.text(this.model.message);
-            return this;
-        }
-    });
-
-
     var ContentMessageView = Backbone.View.extend({
         tagName: 'div',
         initialize: function() {
@@ -65,8 +50,11 @@
             if (errors && errors.length) {
                 this.$el.find('.bubble').append(
                     errors.map(function(error) {
-                        return new ErrorView({model: error}).render().el;
-                    })
+                        return new Whisper.MessageErrorView({
+                            model: error,
+                            message: this.model
+                        }).render().el;
+                    }.bind(this))
                 );
             }
         }

--- a/libtextsecure/axolotl_wrapper.js
+++ b/libtextsecure/axolotl_wrapper.js
@@ -109,19 +109,13 @@
         }
     };
 
-    var wipeIdentityAndTryMessageAgain = function(from, encodedMessage, message_id) {
+    var wipeIdentityAndTryMessageAgain = function(from, encodedMessage, onsuccess, onfailure) {
         // Wipe identity key!
         //TODO: Encapsuate with the rest of textsecure.storage.devices
         textsecure.storage.removeEncrypted("devices" + from.split('.')[0]);
         //TODO: Probably breaks with a devicecontrol message
-        return axolotl.protocol.handlePreKeyWhisperMessage(from, encodedMessage).then(decodeMessageContents).then(
-            function(pushMessageContent) {
-                extension.trigger('message:decrypted', {
-                    message_id : message_id,
-                    data       : pushMessageContent
-                });
-            }
-        );
+        return axolotl.protocol.handlePreKeyWhisperMessage(from, encodedMessage).
+          then(decodeMessageContents).then(onsuccess).catch(onfailure);
     }
     textsecure.replay.registerFunction(wipeIdentityAndTryMessageAgain, textsecure.replay.Type.INIT_SESSION);
 })();

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -42,10 +42,12 @@
     ReplayableError.prototype.replay = function() {
         var args = Array.prototype.slice.call(arguments);
         args.shift();
-        args = this.args.concat(args);
+        args = this.args.concat(args, this.onsuccess, this.onfailure);
 
         registeredFunctions[this.functionCode].apply(window, args);
     };
+    ReplayableError.prototype.onsuccess = function() {};
+    ReplayableError.prototype.onfailure = function() {};
 
     function IncomingIdentityKeyError(number, message) {
         ReplayableError.call(this, {

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -127,21 +127,15 @@ window.textsecure.messaging = function() {
         }
     }
 
-    var tryMessageAgain = function(number, encodedMessage, message_id) {
-        var message = new Whisper.MessageCollection().add({id: message_id});
-        message.fetch().then(function() {
-            //TODO: Encapsuate with the rest of textsecure.storage.devices
-            textsecure.storage.removeEncrypted("devices" + number);
-            var proto = textsecure.protobuf.PushMessageContent.decode(encodedMessage, 'binary');
-            sendMessageProto(message.get('sent_at'), [number], proto, function(res) {
-                if (res.failure.length > 0)
-                    message.set('errors', res.failure);
-                else
-                    message.set('errors', []);
-                message.save().then(function(){
-                    extension.trigger('message', message); // notify frontend listeners
-                });
-            });
+    var tryMessageAgain = function(number, encodedMessage, timestamp, onsuccess, onfailure) {
+        //TODO: Encapsuate with the rest of textsecure.storage.devices
+        textsecure.storage.removeEncrypted("devices" + number);
+        var proto = textsecure.protobuf.PushMessageContent.decode(encodedMessage, 'binary');
+        sendMessageProto(timestamp, [number], proto, function(res) {
+            if (res.failure.length > 0)
+                onfailure(res.failure);
+            else
+                onsuccess();
         });
     };
     textsecure.replay.registerFunction(tryMessageAgain, textsecure.replay.Type.SEND_MESSAGE);


### PR DESCRIPTION
Refactor replayable errors and identity wipe handlers so that libtextsecure is not dependent on app-level objects like message models or the `extension` object.

Instead, they accepts success and failure callbacks from the caller.