### PR TITLE
Register Input Handling

### DIFF
--- a/js/register.js
+++ b/js/register.js
@@ -81,8 +81,8 @@
     $('#form').submit(function(e) {
         e.preventDefault();
         log('registering');
-        var number = $('input.number').val();
-        var verificationCode = $('#code').val();
+        var number = phoneView.validateNumber();
+        var verificationCode = $('#code').val().replace(/\D+/g, "");
         var signalingKey = textsecure.crypto.getRandomBytes(32 + 20);
 
         var password = btoa(getString(textsecure.crypto.getRandomBytes(16)));


### PR DESCRIPTION
I had some trouble with the registration..
Quickly checked TextSecure Server API and found the problems:
number has to be valid PSTN. (Including regionCode, precisely what validateNumber() returns)
verificationCode has to be all numbers, no dashes or spaces