### PR TITLE
Refactor storage in libtextsecure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,7 @@ module.exports = function(grunt) {
 
           'libtextsecure/crypto.js',
           'libtextsecure/storage.js',
+          'libtextsecure/storage/user.js',
           'libtextsecure/storage/devices.js',
           'libtextsecure/storage/groups.js',
           'libtextsecure/protobufs.js',

--- a/js/background.js
+++ b/js/background.js
@@ -96,8 +96,8 @@
                 type           : 'incoming'
             });
 
-            var newUnreadCount = textsecure.storage.getUnencrypted("unreadCount", 0) + 1;
-            textsecure.storage.putUnencrypted("unreadCount", newUnreadCount);
+            var newUnreadCount = textsecure.storage.get("unreadCount", 0) + 1;
+            textsecure.storage.put("unreadCount", newUnreadCount);
             extension.navigator.setBadgeText(newUnreadCount);
 
             conversation.save().then(function() {

--- a/js/inbox_controller.js
+++ b/js/inbox_controller.js
@@ -33,14 +33,14 @@
     inbox.on('change:unreadCount', function(model, count) {
         var prev = model.previous('unreadCount');
         if (count < prev) { // decreased
-            var newUnreadCount = textsecure.storage.getUnencrypted("unreadCount") - (prev - count);
+            var newUnreadCount = textsecure.storage.get("unreadCount") - (prev - count);
             if (newUnreadCount <= 0) {
                 newUnreadCount = 0;
                 extension.navigator.setBadgeText("");
             } else {
                 extension.navigator.setBadgeText(newUnreadCount);
             }
-            textsecure.storage.putUnencrypted("unreadCount", newUnreadCount);
+            textsecure.storage.put("unreadCount", newUnreadCount);
         }
     });
 

--- a/js/index.js
+++ b/js/index.js
@@ -19,7 +19,7 @@
     var bg = extension.windows.getBackground();
 
     window.Whisper = window.Whisper || {};
-    if (bg.textsecure.storage.getUnencrypted("number_id") === undefined) {
+    if (bg.textsecure.storage.user.getNumber() === undefined) {
         window.location = '/options.html';
     } else {
         new bg.Whisper.InboxView().$el.prependTo(bg.$('body',document));

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37698,8 +37698,6 @@ window.axolotl.sessions = {
 })();
 
 })();
-//TODO: Remove almost everything here...
-
 'use strict';
 
 ;(function() {
@@ -37820,7 +37818,6 @@ window.axolotl.sessions = {
     };
 
     var tryMessageAgain = function(from, encodedMessage) {
-        //TODO: Probably breaks with a devicecontrol message
         return textsecure.protocol_wrapper.handlePreKeyWhisperMessage(from, encodedMessage).then(decodeMessageContents);
     }
     textsecure.replay.registerFunction(tryMessageAgain, textsecure.replay.Type.INIT_SESSION);

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37705,16 +37705,16 @@ window.axolotl.sessions = {
 ;(function() {
     var axolotlInstance = axolotl.protocol({
             getMyRegistrationId: function() {
-                return textsecure.storage.getUnencrypted("registrationId");
+                return textsecure.storage.get("registrationId");
             },
             put: function(key, value) {
-                return textsecure.storage.putEncrypted(key, value);
+                return textsecure.storage.put(key, value);
             },
             get: function(key, defaultValue) {
-                return textsecure.storage.getEncrypted(key, defaultValue);
+                return textsecure.storage.get(key, defaultValue);
             },
             remove: function(key) {
-                return textsecure.storage.removeEncrypted(key);
+                return textsecure.storage.remove(key);
             },
 
             identityKeys: {
@@ -37876,7 +37876,7 @@ window.axolotl.sessions = {
     window.textsecure.crypto = {
         // Decrypts message into a raw string
         decryptWebsocketMessage: function(message) {
-            var signaling_key = textsecure.storage.getEncrypted("signaling_key"); //TODO: in crypto_storage
+            var signaling_key = textsecure.storage.get("signaling_key"); //TODO: in crypto_storage
             var aes_key = toArrayBuffer(signaling_key.substring(0, 32));
             var mac_key = toArrayBuffer(signaling_key.substring(32, 32 + 20));
 
@@ -37961,45 +37961,25 @@ window.axolotl.sessions = {
     window.textsecure.storage = window.textsecure.storage || {};
 
     window.textsecure.storage = {
-
         /*****************************
         *** Base Storage Routines ***
         *****************************/
-        putEncrypted: function(key, value) {
-            //TODO
+        put: function(key, value) {
             if (value === undefined)
                 throw new Error("Tried to store undefined");
-            localStorage.setItem("e" + key, textsecure.utils.jsonThing(value));
+            localStorage.setItem("" + key, textsecure.utils.jsonThing(value));
         },
 
-        getEncrypted: function(key, defaultValue) {
-            //TODO
-            var value = localStorage.getItem("e" + key);
+        get: function(key, defaultValue) {
+            var value = localStorage.getItem("" + key);
             if (value === null)
                 return defaultValue;
             return JSON.parse(value);
         },
 
-        removeEncrypted: function(key) {
-            localStorage.removeItem("e" + key);
+        remove: function(key) {
+            localStorage.removeItem("" + key);
         },
-
-        putUnencrypted: function(key, value) {
-            if (value === undefined)
-                throw new Error("Tried to store undefined");
-            localStorage.setItem("u" + key, textsecure.utils.jsonThing(value));
-        },
-
-        getUnencrypted: function(key, defaultValue) {
-            var value = localStorage.getItem("u" + key);
-            if (value === null)
-                return defaultValue;
-            return JSON.parse(value);
-        },
-
-        removeUnencrypted: function(key) {
-            localStorage.removeItem("u" + key);
-        }
     };
 })();
 
@@ -38031,25 +38011,24 @@ window.axolotl.sessions = {
 
     window.textsecure.storage.user = {
         setNumberAndDeviceId: function(number, deviceId) {
-            textsecure.storage.putUnencrypted("number_id", number + "." + deviceId);
+            textsecure.storage.put("number_id", number + "." + deviceId);
         },
 
         getNumber: function(key, defaultValue) {
-            var number_id = textsecure.storage.getUnencrypted("number_id");
+            var number_id = textsecure.storage.get("number_id");
             if (number_id === undefined)
                 return undefined;
             return textsecure.utils.unencodeNumber(number_id)[0];
         },
 
         getDeviceId: function(key) {
-            var number_id = textsecure.storage.getUnencrypted("number_id");
+            var number_id = textsecure.storage.get("number_id");
             if (number_id === undefined)
                 return undefined;
             return textsecure.utils.unencodeNumber(number_id)[1];
         }
     };
 })();
-
 
 /* vim: ts=4:sw=4
  *
@@ -38099,7 +38078,7 @@ window.axolotl.sessions = {
         },
 
         getDeviceObjectsForNumber: function(number) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
                return [];
             for (key in map.devices) {
@@ -38115,23 +38094,23 @@ window.axolotl.sessions = {
         },
 
         getIdentityKeyForNumber: function(number) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             return map === undefined ? undefined : map.identityKey;
         },
 
         checkSaveIdentityKeyForNumber: function(number, identityKey) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
-                textsecure.storage.putEncrypted("devices" + number, { devices: [], identityKey: identityKey});
+                textsecure.storage.put("devices" + number, { devices: [], identityKey: identityKey});
             else if (getString(map.identityKey) !== getString(identityKey))
                 throw new Error("Attempted to overwrite a different identity key");
         },
 
         removeIdentityKeyForNumber: function(number) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
                 throw new Error("Tried to remove identity for unknown number");
-            textsecure.storage.removeEncrypted("devices" + number);
+            textsecure.storage.remove("devices" + number);
         },
 
         getDeviceObject: function(encodedNumber, returnIdentityKey) {
@@ -38157,7 +38136,7 @@ window.axolotl.sessions = {
         },
 
         removeDeviceIdsForNumber: function(number, deviceIdsToRemove) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
                 throw new Error("Tried to remove device for unknown number");
 
@@ -38179,10 +38158,10 @@ window.axolotl.sessions = {
                 throw new Error("Tried to remove unknown device");
 
             if (newDevices.length === 0)
-                textsecure.storage.removeEncrypted("devices" + number);
+                textsecure.storage.remove("devices" + number);
             else {
                 map.devices = newDevices;
-                textsecure.storage.putEncrypted("devices" + number, map);
+                textsecure.storage.put("devices" + number, map);
             }
         }
     };
@@ -38192,7 +38171,7 @@ window.axolotl.sessions = {
             throw new Error("Tried to store invalid deviceObject");
 
         var number = textsecure.utils.unencodeNumber(deviceObject.encodedNumber)[0];
-        var map = textsecure.storage.getEncrypted("devices" + number);
+        var map = textsecure.storage.get("devices" + number);
 
         if (deviceObject.sessions !== undefined)
             deviceObject.sessions = deviceObject.sessions.serialize()
@@ -38223,7 +38202,7 @@ window.axolotl.sessions = {
                 map.devices.push(deviceObject);
         }
 
-        textsecure.storage.putEncrypted("devices" + number, map);
+        textsecure.storage.put("devices" + number, map);
     };
 })();
 
@@ -38254,10 +38233,10 @@ window.axolotl.sessions = {
 
     window.textsecure.storage.groups = {
         createNewGroup: function(numbers, groupId) {
-            if (groupId !== undefined && textsecure.storage.getEncrypted("group" + groupId) !== undefined)
+            if (groupId !== undefined && textsecure.storage.get("group" + groupId) !== undefined)
                 throw new Error("Tried to recreate group");
 
-            while (groupId === undefined || textsecure.storage.getEncrypted("group" + groupId) !== undefined)
+            while (groupId === undefined || textsecure.storage.get("group" + groupId) !== undefined)
                 groupId = getString(textsecure.crypto.getRandomBytes(16));
 
             var me = textsecure.storage.user.getNumber();
@@ -38280,13 +38259,13 @@ window.axolotl.sessions = {
             for (var i in finalNumbers)
                 groupObject.numberRegistrationIds[finalNumbers[i]] = {};
 
-            textsecure.storage.putEncrypted("group" + groupId, groupObject);
+            textsecure.storage.put("group" + groupId, groupObject);
 
             return {id: groupId, numbers: finalNumbers};
         },
 
         getNumbers: function(groupId) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -38294,7 +38273,7 @@ window.axolotl.sessions = {
         },
 
         removeNumber: function(groupId, number) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -38306,14 +38285,14 @@ window.axolotl.sessions = {
             if (i > -1) {
                 group.numbers.slice(i, 1);
                 delete group.numberRegistrationIds[number];
-                textsecure.storage.putEncrypted("group" + groupId, group);
+                textsecure.storage.put("group" + groupId, group);
             }
 
             return group.numbers;
         },
 
         addNumbers: function(groupId, numbers) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -38327,16 +38306,16 @@ window.axolotl.sessions = {
                 }
             }
 
-            textsecure.storage.putEncrypted("group" + groupId, group);
+            textsecure.storage.put("group" + groupId, group);
             return group.numbers;
         },
 
         deleteGroup: function(groupId) {
-            textsecure.storage.removeEncrypted("group" + groupId);
+            textsecure.storage.remove("group" + groupId);
         },
 
         getGroup: function(groupId) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -38344,7 +38323,7 @@ window.axolotl.sessions = {
         },
 
         needUpdateByDeviceRegistrationId: function(groupId, number, encodedNumber, registrationId) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 throw new Error("Unknown group for device registration id");
 
@@ -38356,7 +38335,7 @@ window.axolotl.sessions = {
 
             var needUpdate = group.numberRegistrationIds[number][encodedNumber] !== undefined;
             group.numberRegistrationIds[number][encodedNumber] = registrationId;
-            textsecure.storage.putEncrypted("group" + groupId, group);
+            textsecure.storage.put("group" + groupId, group);
             return needUpdate;
         },
     };
@@ -38879,19 +38858,19 @@ textsecure.processDecrypted = function(decrypted, source) {
 
 window.textsecure.registerSingleDevice = function(number, verificationCode, stepDone) {
     var signalingKey = textsecure.crypto.getRandomBytes(32 + 20);
-    textsecure.storage.putEncrypted('signaling_key', signalingKey);
+    textsecure.storage.put('signaling_key', signalingKey);
 
     var password = btoa(getString(textsecure.crypto.getRandomBytes(16)));
     password = password.substring(0, password.length - 2);
-    textsecure.storage.putEncrypted("password", password);
+    textsecure.storage.put("password", password);
 
     var registrationId = new Uint16Array(textsecure.crypto.getRandomBytes(2))[0];
     registrationId = registrationId & 0x3fff;
-    textsecure.storage.putUnencrypted("registrationId", registrationId);
+    textsecure.storage.put("registrationId", registrationId);
 
     return textsecure.api.confirmCode(number, verificationCode, password, signalingKey, registrationId, true).then(function() {
         textsecure.storage.user.setNumberAndDeviceId(number, 1);
-        textsecure.storage.putUnencrypted("regionCode", libphonenumber.util.getRegionCodeForNumber(number));
+        textsecure.storage.put("regionCode", libphonenumber.util.getRegionCodeForNumber(number));
         stepDone(1);
 
         return textsecure.protocol_wrapper.generateKeys().then(function(keys) {
@@ -38909,19 +38888,19 @@ window.textsecure.registerSecondDevice = function(encodedProvisionEnvelope, cryp
         stepDone(1);
 
         var signalingKey = textsecure.crypto.getRandomBytes(32 + 20);
-        textsecure.storage.putEncrypted('signaling_key', signalingKey);
+        textsecure.storage.put('signaling_key', signalingKey);
 
         var password = btoa(getString(textsecure.crypto.getRandomBytes(16)));
         password = password.substring(0, password.length - 2);
-        textsecure.storage.putEncrypted("password", password);
+        textsecure.storage.put("password", password);
 
         var registrationId = new Uint16Array(textsecure.crypto.getRandomBytes(2))[0];
         registrationId = registrationId & 0x3fff;
-        textsecure.storage.putUnencrypted("registrationId", registrationId);
+        textsecure.storage.put("registrationId", registrationId);
 
         return textsecure.api.confirmCode(identityKey.number, identityKey.provisioningCode, password, signalingKey, registrationId, false).then(function(result) {
             textsecure.storage.user.setNumberAndDeviceId(identityKey.number, result.deviceId);
-            textsecure.storage.putUnencrypted("regionCode", libphonenumber.util.getRegionCodeForNumber(identityKey.number));
+            textsecure.storage.put("regionCode", libphonenumber.util.getRegionCodeForNumber(identityKey.number));
             stepDone(2);
 
             return textsecure.protocol_wrapper.generateKeys().then(function(keys) {
@@ -39130,7 +39109,7 @@ window.textsecure.api = function () {
 
         if (param.do_auth) {
             param.user      = textsecure.storage.user.getNumber() + "." + textsecure.storage.user.getDeviceId();
-            param.password  = textsecure.storage.getEncrypted("password");
+            param.password  = textsecure.storage.get("password");
         }
 
         return new Promise(function (resolve, reject) {
@@ -39356,7 +39335,7 @@ window.textsecure.api = function () {
         var params = '';
         if (auth) {
             var user = textsecure.storage.user.getNumber() + "." + textsecure.storage.user.getDeviceId();
-            var password = textsecure.storage.getEncrypted("password");
+            var password = textsecure.storage.get("password");
             var params = 'login=%2B' + encodeURIComponent(user.substring(1)) + '&password=' + encodeURIComponent(password);
         }
         return window.textsecure.websocket(URL+params)

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37708,13 +37708,13 @@ window.axolotl.sessions = {
                 return textsecure.storage.get("registrationId");
             },
             put: function(key, value) {
-                return textsecure.storage.put(key, value);
+                return textsecure.storage.put("libaxolotl" + key, value);
             },
             get: function(key, defaultValue) {
-                return textsecure.storage.get(key, defaultValue);
+                return textsecure.storage.get("libaxolotl" + key, defaultValue);
             },
             remove: function(key) {
-                return textsecure.storage.remove(key);
+                return textsecure.storage.remove("libaxolotl" + key);
             },
 
             identityKeys: {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37726,23 +37726,10 @@ window.axolotl.sessions = {
 
             sessions: {
                 get: function(identifier) {
-                    var device = textsecure.storage.devices.getDeviceObject(identifier, true);
-                    if (device === undefined || device.sessions === undefined)
-                        return undefined;
-                    return device.sessions;
+                    return textsecure.storage.sessions.getSessionsForNumber(identifier);
                 },
                 put: function(identifier, record) {
-                    var device = textsecure.storage.devices.getDeviceObject(identifier);
-                    if (device === undefined) {
-                        device = { encodedNumber: identifier,
-                                   //TODO: Remove this duplication
-                                   identityKey: record.identityKey
-                                 };
-                    }
-                    if (getString(device.identityKey) !== getString(record.identityKey))
-                        throw new Error("Tried to put session for device with changed identity key");
-                    device.sessions = record;
-                    return textsecure.storage.devices.saveDeviceObject(device);
+                    return textsecure.storage.sessions.putSessionsForDevice(identifier, record);
                 }
             }
         },
@@ -38064,6 +38051,28 @@ window.axolotl.sessions = {
     **********************/
     window.textsecure = window.textsecure || {};
     window.textsecure.storage = window.textsecure.storage || {};
+
+    window.textsecure.storage.sessions = {
+        getSessionsForNumber: function(encodedNumber) {
+            var device = textsecure.storage.devices.getDeviceObject(encodedNumber, true);
+            if (device === undefined || device.sessions === undefined)
+                return undefined;
+            return device.sessions;
+        },
+        putSessionsForDevice: function(encodedNumber, sessions) {
+            var device = textsecure.storage.devices.getDeviceObject(encodedNumber);
+            if (device === undefined) {
+                device = { encodedNumber: encodedNumber,
+                           //TODO: Remove this duplication
+                           identityKey: sessions.identityKey
+                         };
+            }
+            if (getString(device.identityKey) !== getString(sessions.identityKey))
+                throw new Error("Tried to put session for device with changed identity key");
+            device.sessions = sessions;
+            return textsecure.storage.devices.saveDeviceObject(device);
+        },
+    };
 
     window.textsecure.storage.devices = {
         saveDeviceObject: function(deviceObject) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37960,7 +37960,8 @@ window.axolotl.sessions = {
     window.textsecure = window.textsecure || {};
     window.textsecure.storage = window.textsecure.storage || {};
 
-    window.textsecure.storage = {
+    // Overrideable storage implementation
+    window.textsecure.storage.impl = {
         /*****************************
         *** Base Storage Routines ***
         *****************************/
@@ -37980,6 +37981,18 @@ window.axolotl.sessions = {
         remove: function(key) {
             localStorage.removeItem("" + key);
         },
+    };
+
+    window.textsecure.storage.put = function(key, value) {
+        return textsecure.storage.impl.put(key, value);
+    };
+
+    window.textsecure.storage.get = function(key, defaultValue) {
+        return textsecure.storage.impl.get(key, defaultValue);
+    };
+
+    window.textsecure.storage.remove = function(key) {
+        return textsecure.storage.impl.remove(key);
     };
 })();
 

--- a/js/options.js
+++ b/js/options.js
@@ -37,11 +37,7 @@
 
     $(function() {
         if (textsecure.registration.isDone()) {
-            $('#complete-number').text(
-                textsecure.utils.unencodeNumber(
-                    textsecure.storage.getUnencrypted("number_id")
-                )[0]
-            );//TODO: no
+            $('#complete-number').text(textsecure.storage.user.getNumber());
             $('#setup-complete').show().addClass('in');
             initOptions();
         } else {

--- a/js/register.js
+++ b/js/register.js
@@ -36,9 +36,9 @@
     var phoneView = new Whisper.PhoneInputView({el: $('#phone-number-input')});
     phoneView.$el.find('input.number').intlTelInput();
 
-    var number = textsecure.storage.getUnencrypted('number_id');
+    var number = textsecure.storage.user.getNumber();
     if (number) {
-        $('input.number').val(number.split('.')[0]);
+        $('input.number').val(number);
     }
 
     $('input.number').on('validation', function() {
@@ -98,7 +98,7 @@
         textsecure.storage.putUnencrypted('registrationId', registrationId);
         textsecure.storage.putEncrypted('signaling_key', signalingKey);
         textsecure.storage.putEncrypted('password', password);
-        textsecure.storage.putUnencrypted('number_id', number + '.1');
+        textsecure.storage.user.setNumberAndDeviceId(number, 1);
         textsecure.storage.putUnencrypted('regionCode', libphonenumber.util.getRegionCodeForNumber(number));
 
         log('verifying code');

--- a/js/register.js
+++ b/js/register.js
@@ -95,11 +95,11 @@
         localStorage.clear();
 
         localStorage.setItem('first_install_ran', 1);
-        textsecure.storage.putUnencrypted('registrationId', registrationId);
-        textsecure.storage.putEncrypted('signaling_key', signalingKey);
-        textsecure.storage.putEncrypted('password', password);
+        textsecure.storage.put('registrationId', registrationId);
+        textsecure.storage.put('signaling_key', signalingKey);
+        textsecure.storage.put('password', password);
         textsecure.storage.user.setNumberAndDeviceId(number, 1);
-        textsecure.storage.putUnencrypted('regionCode', libphonenumber.util.getRegionCodeForNumber(number));
+        textsecure.storage.put('regionCode', libphonenumber.util.getRegionCodeForNumber(number));
 
         log('verifying code');
         return textsecure.api.confirmCode(

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -74,9 +74,7 @@
                 var view = new Whisper.KeyVerificationView({
                     model: {
                         their_key: textsecure.storage.devices.getIdentityKeyForNumber(number),
-                        your_key: textsecure.storage.devices.getIdentityKeyForNumber(
-                            textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0]
-                        )
+                        your_key: textsecure.storage.devices.getIdentityKeyForNumber(textsecure.storage.user.getNumber())
                     }
                 });
                 this.$el.hide();

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -58,9 +58,7 @@
             var view = new Whisper.KeyVerificationView({
                 model: {
                     their_key: textsecure.storage.devices.getIdentityKeyForNumber(number),
-                    your_key: textsecure.storage.devices.getIdentityKeyForNumber(
-                        textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0]
-                    )
+                    your_key: textsecure.storage.devices.getIdentityKeyForNumber(textsecure.storage.user.getNumber())
                 }
             });
             this.$el.hide();

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -96,7 +96,7 @@ window.textsecure.api = function () {
 
         if (param.do_auth) {
             param.user      = textsecure.storage.user.getNumber() + "." + textsecure.storage.user.getDeviceId();
-            param.password  = textsecure.storage.getEncrypted("password");
+            param.password  = textsecure.storage.get("password");
         }
 
         return new Promise(function (resolve, reject) {
@@ -322,7 +322,7 @@ window.textsecure.api = function () {
         var params = '';
         if (auth) {
             var user = textsecure.storage.user.getNumber() + "." + textsecure.storage.user.getDeviceId();
-            var password = textsecure.storage.getEncrypted("password");
+            var password = textsecure.storage.get("password");
             var params = 'login=%2B' + encodeURIComponent(user.substring(1)) + '&password=' + encodeURIComponent(password);
         }
         return window.textsecure.websocket(URL+params)

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -95,7 +95,7 @@ window.textsecure.api = function () {
         }
 
         if (param.do_auth) {
-            param.user      = textsecure.storage.getUnencrypted("number_id");
+            param.user      = textsecure.storage.user.getNumber() + "." + textsecure.storage.user.getDeviceId();
             param.password  = textsecure.storage.getEncrypted("password");
         }
 
@@ -321,7 +321,7 @@ window.textsecure.api = function () {
         var URL = URL_BASE.replace(/^http/g, 'ws') + url + '/?';
         var params = '';
         if (auth) {
-            var user = textsecure.storage.getUnencrypted("number_id");
+            var user = textsecure.storage.user.getNumber() + "." + textsecure.storage.user.getDeviceId();
             var password = textsecure.storage.getEncrypted("password");
             var params = 'login=%2B' + encodeURIComponent(user.substring(1)) + '&password=' + encodeURIComponent(password);
         }

--- a/libtextsecure/axolotl_wrapper.js
+++ b/libtextsecure/axolotl_wrapper.js
@@ -26,23 +26,10 @@
 
             sessions: {
                 get: function(identifier) {
-                    var device = textsecure.storage.devices.getDeviceObject(identifier, true);
-                    if (device === undefined || device.sessions === undefined)
-                        return undefined;
-                    return device.sessions;
+                    return textsecure.storage.sessions.getSessionsForNumber(identifier);
                 },
                 put: function(identifier, record) {
-                    var device = textsecure.storage.devices.getDeviceObject(identifier);
-                    if (device === undefined) {
-                        device = { encodedNumber: identifier,
-                                   //TODO: Remove this duplication
-                                   identityKey: record.identityKey
-                                 };
-                    }
-                    if (getString(device.identityKey) !== getString(record.identityKey))
-                        throw new Error("Tried to put session for device with changed identity key");
-                    device.sessions = record;
-                    return textsecure.storage.devices.saveDeviceObject(device);
+                    return textsecure.storage.sessions.putSessionsForDevice(identifier, record);
                 }
             }
         },

--- a/libtextsecure/axolotl_wrapper.js
+++ b/libtextsecure/axolotl_wrapper.js
@@ -1,5 +1,3 @@
-//TODO: Remove almost everything here...
-
 'use strict';
 
 ;(function() {
@@ -120,7 +118,6 @@
     };
 
     var tryMessageAgain = function(from, encodedMessage) {
-        //TODO: Probably breaks with a devicecontrol message
         return textsecure.protocol_wrapper.handlePreKeyWhisperMessage(from, encodedMessage).then(decodeMessageContents);
     }
     textsecure.replay.registerFunction(tryMessageAgain, textsecure.replay.Type.INIT_SESSION);

--- a/libtextsecure/axolotl_wrapper.js
+++ b/libtextsecure/axolotl_wrapper.js
@@ -5,16 +5,16 @@
 ;(function() {
     var axolotlInstance = axolotl.protocol({
             getMyRegistrationId: function() {
-                return textsecure.storage.getUnencrypted("registrationId");
+                return textsecure.storage.get("registrationId");
             },
             put: function(key, value) {
-                return textsecure.storage.putEncrypted(key, value);
+                return textsecure.storage.put(key, value);
             },
             get: function(key, defaultValue) {
-                return textsecure.storage.getEncrypted(key, defaultValue);
+                return textsecure.storage.get(key, defaultValue);
             },
             remove: function(key) {
-                return textsecure.storage.removeEncrypted(key);
+                return textsecure.storage.remove(key);
             },
 
             identityKeys: {

--- a/libtextsecure/axolotl_wrapper.js
+++ b/libtextsecure/axolotl_wrapper.js
@@ -8,13 +8,13 @@
                 return textsecure.storage.get("registrationId");
             },
             put: function(key, value) {
-                return textsecure.storage.put(key, value);
+                return textsecure.storage.put("libaxolotl" + key, value);
             },
             get: function(key, defaultValue) {
-                return textsecure.storage.get(key, defaultValue);
+                return textsecure.storage.get("libaxolotl" + key, defaultValue);
             },
             remove: function(key) {
-                return textsecure.storage.remove(key);
+                return textsecure.storage.remove("libaxolotl" + key);
             },
 
             identityKeys: {

--- a/libtextsecure/crypto.js
+++ b/libtextsecure/crypto.js
@@ -48,7 +48,7 @@
     window.textsecure.crypto = {
         // Decrypts message into a raw string
         decryptWebsocketMessage: function(message) {
-            var signaling_key = textsecure.storage.getEncrypted("signaling_key"); //TODO: in crypto_storage
+            var signaling_key = textsecure.storage.get("signaling_key"); //TODO: in crypto_storage
             var aes_key = toArrayBuffer(signaling_key.substring(0, 32));
             var mac_key = toArrayBuffer(signaling_key.substring(32, 32 + 20));
 

--- a/libtextsecure/helpers.js
+++ b/libtextsecure/helpers.js
@@ -255,19 +255,19 @@ textsecure.processDecrypted = function(decrypted, source) {
 
 window.textsecure.registerSingleDevice = function(number, verificationCode, stepDone) {
     var signalingKey = textsecure.crypto.getRandomBytes(32 + 20);
-    textsecure.storage.putEncrypted('signaling_key', signalingKey);
+    textsecure.storage.put('signaling_key', signalingKey);
 
     var password = btoa(getString(textsecure.crypto.getRandomBytes(16)));
     password = password.substring(0, password.length - 2);
-    textsecure.storage.putEncrypted("password", password);
+    textsecure.storage.put("password", password);
 
     var registrationId = new Uint16Array(textsecure.crypto.getRandomBytes(2))[0];
     registrationId = registrationId & 0x3fff;
-    textsecure.storage.putUnencrypted("registrationId", registrationId);
+    textsecure.storage.put("registrationId", registrationId);
 
     return textsecure.api.confirmCode(number, verificationCode, password, signalingKey, registrationId, true).then(function() {
         textsecure.storage.user.setNumberAndDeviceId(number, 1);
-        textsecure.storage.putUnencrypted("regionCode", libphonenumber.util.getRegionCodeForNumber(number));
+        textsecure.storage.put("regionCode", libphonenumber.util.getRegionCodeForNumber(number));
         stepDone(1);
 
         return textsecure.protocol_wrapper.generateKeys().then(function(keys) {
@@ -285,19 +285,19 @@ window.textsecure.registerSecondDevice = function(encodedProvisionEnvelope, cryp
         stepDone(1);
 
         var signalingKey = textsecure.crypto.getRandomBytes(32 + 20);
-        textsecure.storage.putEncrypted('signaling_key', signalingKey);
+        textsecure.storage.put('signaling_key', signalingKey);
 
         var password = btoa(getString(textsecure.crypto.getRandomBytes(16)));
         password = password.substring(0, password.length - 2);
-        textsecure.storage.putEncrypted("password", password);
+        textsecure.storage.put("password", password);
 
         var registrationId = new Uint16Array(textsecure.crypto.getRandomBytes(2))[0];
         registrationId = registrationId & 0x3fff;
-        textsecure.storage.putUnencrypted("registrationId", registrationId);
+        textsecure.storage.put("registrationId", registrationId);
 
         return textsecure.api.confirmCode(identityKey.number, identityKey.provisioningCode, password, signalingKey, registrationId, false).then(function(result) {
             textsecure.storage.user.setNumberAndDeviceId(identityKey.number, result.deviceId);
-            textsecure.storage.putUnencrypted("regionCode", libphonenumber.util.getRegionCodeForNumber(identityKey.number));
+            textsecure.storage.put("regionCode", libphonenumber.util.getRegionCodeForNumber(identityKey.number));
             stepDone(2);
 
             return textsecure.protocol_wrapper.generateKeys().then(function(keys) {

--- a/libtextsecure/helpers.js
+++ b/libtextsecure/helpers.js
@@ -161,7 +161,7 @@ textsecure.processDecrypted = function(decrypted, source) {
     if (decrypted.flags == null)
         decrypted.flags = 0;
 
-    if (decrypted.sync !== null && textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0] != source)
+    if (decrypted.sync !== null && textsecure.storage.user.getNumber() != source)
         throw new Error("Got sync context on a message not from a peer device");
 
     if ((decrypted.flags & textsecure.protobuf.PushMessageContent.Flags.END_SESSION)
@@ -266,8 +266,7 @@ window.textsecure.registerSingleDevice = function(number, verificationCode, step
     textsecure.storage.putUnencrypted("registrationId", registrationId);
 
     return textsecure.api.confirmCode(number, verificationCode, password, signalingKey, registrationId, true).then(function() {
-        var numberId = number + ".1";
-        textsecure.storage.putUnencrypted("number_id", numberId);
+        textsecure.storage.user.setNumberAndDeviceId(number, 1);
         textsecure.storage.putUnencrypted("regionCode", libphonenumber.util.getRegionCodeForNumber(number));
         stepDone(1);
 
@@ -297,8 +296,7 @@ window.textsecure.registerSecondDevice = function(encodedProvisionEnvelope, cryp
         textsecure.storage.putUnencrypted("registrationId", registrationId);
 
         return textsecure.api.confirmCode(identityKey.number, identityKey.provisioningCode, password, signalingKey, registrationId, false).then(function(result) {
-            var numberId = identityKey.number + "." + result.deviceId;
-            textsecure.storage.putUnencrypted("number_id", numberId);
+            textsecure.storage.user.setNumberAndDeviceId(identityKey.number, result.deviceId);
             textsecure.storage.putUnencrypted("regionCode", libphonenumber.util.getRegionCodeForNumber(identityKey.number));
             stepDone(2);
 

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -256,9 +256,8 @@ window.textsecure.messaging = function() {
     }
 
     var sendSyncMessage = function(message, timestamp, destination) {
-        var numberDevice = textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"));
-        var myNumber = numberDevice[0];
-        var myDevice = numberDevice[1];
+        var myNumber = textsecure.storage.user.getNumber();
+        var myDevice = textsecure.storage.user.getDeviceId();
         if (myDevice != 1) {
             var sync_message = textsecure.protobuf.PushMessageContent.decode(message.encode());
             sync_message.sync = new textsecure.protobuf.PushMessageContent.SyncMessageContext();
@@ -270,7 +269,7 @@ window.textsecure.messaging = function() {
 
     var sendGroupProto = function(numbers, proto, timestamp) {
         timestamp = timestamp || Date.now();
-        var me = textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0];
+        var me = textsecure.storage.user.getNumber();
         numbers = numbers.filter(function(number) { return number != me; });
 
         return new Promise(function(resolve, reject) {

--- a/libtextsecure/storage.js
+++ b/libtextsecure/storage.js
@@ -25,45 +25,25 @@
     window.textsecure.storage = window.textsecure.storage || {};
 
     window.textsecure.storage = {
-
         /*****************************
         *** Base Storage Routines ***
         *****************************/
-        putEncrypted: function(key, value) {
-            //TODO
+        put: function(key, value) {
             if (value === undefined)
                 throw new Error("Tried to store undefined");
-            localStorage.setItem("e" + key, textsecure.utils.jsonThing(value));
+            localStorage.setItem("" + key, textsecure.utils.jsonThing(value));
         },
 
-        getEncrypted: function(key, defaultValue) {
-            //TODO
-            var value = localStorage.getItem("e" + key);
+        get: function(key, defaultValue) {
+            var value = localStorage.getItem("" + key);
             if (value === null)
                 return defaultValue;
             return JSON.parse(value);
         },
 
-        removeEncrypted: function(key) {
-            localStorage.removeItem("e" + key);
+        remove: function(key) {
+            localStorage.removeItem("" + key);
         },
-
-        putUnencrypted: function(key, value) {
-            if (value === undefined)
-                throw new Error("Tried to store undefined");
-            localStorage.setItem("u" + key, textsecure.utils.jsonThing(value));
-        },
-
-        getUnencrypted: function(key, defaultValue) {
-            var value = localStorage.getItem("u" + key);
-            if (value === null)
-                return defaultValue;
-            return JSON.parse(value);
-        },
-
-        removeUnencrypted: function(key) {
-            localStorage.removeItem("u" + key);
-        }
     };
 })();
 

--- a/libtextsecure/storage.js
+++ b/libtextsecure/storage.js
@@ -24,7 +24,8 @@
     window.textsecure = window.textsecure || {};
     window.textsecure.storage = window.textsecure.storage || {};
 
-    window.textsecure.storage = {
+    // Overrideable storage implementation
+    window.textsecure.storage.impl = {
         /*****************************
         *** Base Storage Routines ***
         *****************************/
@@ -44,6 +45,18 @@
         remove: function(key) {
             localStorage.removeItem("" + key);
         },
+    };
+
+    window.textsecure.storage.put = function(key, value) {
+        return textsecure.storage.impl.put(key, value);
+    };
+
+    window.textsecure.storage.get = function(key, defaultValue) {
+        return textsecure.storage.impl.get(key, defaultValue);
+    };
+
+    window.textsecure.storage.remove = function(key) {
+        return textsecure.storage.impl.remove(key);
     };
 })();
 

--- a/libtextsecure/storage/devices.js
+++ b/libtextsecure/storage/devices.js
@@ -23,6 +23,28 @@
     window.textsecure = window.textsecure || {};
     window.textsecure.storage = window.textsecure.storage || {};
 
+    window.textsecure.storage.sessions = {
+        getSessionsForNumber: function(encodedNumber) {
+            var device = textsecure.storage.devices.getDeviceObject(encodedNumber, true);
+            if (device === undefined || device.sessions === undefined)
+                return undefined;
+            return device.sessions;
+        },
+        putSessionsForDevice: function(encodedNumber, sessions) {
+            var device = textsecure.storage.devices.getDeviceObject(encodedNumber);
+            if (device === undefined) {
+                device = { encodedNumber: encodedNumber,
+                           //TODO: Remove this duplication
+                           identityKey: sessions.identityKey
+                         };
+            }
+            if (getString(device.identityKey) !== getString(sessions.identityKey))
+                throw new Error("Tried to put session for device with changed identity key");
+            device.sessions = sessions;
+            return textsecure.storage.devices.saveDeviceObject(device);
+        },
+    };
+
     window.textsecure.storage.devices = {
         saveDeviceObject: function(deviceObject) {
             return internalSaveDeviceObject(deviceObject, false);

--- a/libtextsecure/storage/devices.js
+++ b/libtextsecure/storage/devices.js
@@ -30,6 +30,7 @@
                 return undefined;
             return device.sessions;
         },
+
         putSessionsForDevice: function(encodedNumber, sessions) {
             var device = textsecure.storage.devices.getDeviceObject(encodedNumber);
             if (device === undefined) {
@@ -42,6 +43,13 @@
                 throw new Error("Tried to put session for device with changed identity key");
             device.sessions = sessions;
             return textsecure.storage.devices.saveDeviceObject(device);
+        },
+
+        haveOpenSessionForDevice: function(encodedNumber) {
+            var sessions = textsecure.storage.sessions.getSessionsForNumber(encodedNumber);
+            if (sessions === undefined || !sessions.haveOpenSession())
+                return false;
+            return true;
         },
     };
 

--- a/libtextsecure/storage/devices.js
+++ b/libtextsecure/storage/devices.js
@@ -25,23 +25,45 @@
 
     window.textsecure.storage.sessions = {
         getSessionsForNumber: function(encodedNumber) {
-            var device = textsecure.storage.devices.getDeviceObject(encodedNumber, true);
-            if (device === undefined || device.sessions === undefined)
+            var number = textsecure.utils.unencodeNumber(encodedNumber)[0];
+            var deviceId = textsecure.utils.unencodeNumber(encodedNumber)[1];
+
+            var sessions = textsecure.storage.get("sessions" + number);
+            if (sessions === undefined)
                 return undefined;
-            return device.sessions;
+            if (sessions[deviceId] === undefined)
+                return undefined;
+
+            var record = new axolotl.sessions.RecipientRecord();
+            record.deserialize(sessions[deviceId]);
+            if (getString(textsecure.storage.devices.getIdentityKeyForNumber(number)) !== getString(record.identityKey))
+                throw new Error("Got mismatched identity key on device object load");
+            return record;
         },
 
-        putSessionsForDevice: function(encodedNumber, sessions) {
+        putSessionsForDevice: function(encodedNumber, record) {
+            var number = textsecure.utils.unencodeNumber(encodedNumber)[0];
+            var deviceId = textsecure.utils.unencodeNumber(encodedNumber)[1];
+
+            textsecure.storage.devices.checkSaveIdentityKeyForNumber(number, record.identityKey);
+
+            var sessions = textsecure.storage.get("sessions" + number);
+            if (sessions === undefined)
+                sessions = {};
+            sessions[deviceId] = record.serialize();
+            textsecure.storage.put("sessions" + number, sessions);
+
             var device = textsecure.storage.devices.getDeviceObject(encodedNumber);
             if (device === undefined) {
                 device = { encodedNumber: encodedNumber,
                            //TODO: Remove this duplication
-                           identityKey: sessions.identityKey
+                           identityKey: record.identityKey
                          };
             }
-            if (getString(device.identityKey) !== getString(sessions.identityKey))
+            if (getString(device.identityKey) !== getString(record.identityKey)) {
+                console.error("Got device object with key inconsistent after checkSaveIdentityKeyForNumber returned!");
                 throw new Error("Tried to put session for device with changed identity key");
-            device.sessions = sessions;
+            }
             return textsecure.storage.devices.saveDeviceObject(device);
         },
 
@@ -51,6 +73,12 @@
                 return false;
             return true;
         },
+
+        // Use textsecure.storage.devices.removeIdentityKeyForNumber (which calls this) instead
+        _removeIdentityKeyForNumber: function(number) {
+            textsecure.storage.remove("sessions" + number);
+        },
+
     };
 
     window.textsecure.storage.devices = {
@@ -79,15 +107,6 @@
             var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
                return [];
-            for (key in map.devices) {
-                if (map.devices[key].sessions !== undefined) {
-                    var record = new axolotl.sessions.RecipientRecord();
-                    record.deserialize(map.devices[key].sessions);
-                    if (getString(map.identityKey) !== getString(record.identityKey))
-                        throw new Error("Got mismatched identity key on device object load");
-                    map.devices[key].sessions = record;
-                }
-            }
             return map.devices;
         },
 
@@ -109,6 +128,7 @@
             if (map === undefined)
                 throw new Error("Tried to remove identity for unknown number");
             textsecure.storage.remove("devices" + number);
+            textsecure.storage.sessions._removeIdentityKeyForNumber(number);
         },
 
         getDeviceObject: function(encodedNumber, returnIdentityKey) {
@@ -170,9 +190,6 @@
 
         var number = textsecure.utils.unencodeNumber(deviceObject.encodedNumber)[0];
         var map = textsecure.storage.get("devices" + number);
-
-        if (deviceObject.sessions !== undefined)
-            deviceObject.sessions = deviceObject.sessions.serialize()
 
         if (map === undefined)
             map = { devices: [deviceObject], identityKey: deviceObject.identityKey };

--- a/libtextsecure/storage/devices.js
+++ b/libtextsecure/storage/devices.js
@@ -46,7 +46,7 @@
         },
 
         getDeviceObjectsForNumber: function(number) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
                return [];
             for (key in map.devices) {
@@ -62,23 +62,23 @@
         },
 
         getIdentityKeyForNumber: function(number) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             return map === undefined ? undefined : map.identityKey;
         },
 
         checkSaveIdentityKeyForNumber: function(number, identityKey) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
-                textsecure.storage.putEncrypted("devices" + number, { devices: [], identityKey: identityKey});
+                textsecure.storage.put("devices" + number, { devices: [], identityKey: identityKey});
             else if (getString(map.identityKey) !== getString(identityKey))
                 throw new Error("Attempted to overwrite a different identity key");
         },
 
         removeIdentityKeyForNumber: function(number) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
                 throw new Error("Tried to remove identity for unknown number");
-            textsecure.storage.removeEncrypted("devices" + number);
+            textsecure.storage.remove("devices" + number);
         },
 
         getDeviceObject: function(encodedNumber, returnIdentityKey) {
@@ -104,7 +104,7 @@
         },
 
         removeDeviceIdsForNumber: function(number, deviceIdsToRemove) {
-            var map = textsecure.storage.getEncrypted("devices" + number);
+            var map = textsecure.storage.get("devices" + number);
             if (map === undefined)
                 throw new Error("Tried to remove device for unknown number");
 
@@ -126,10 +126,10 @@
                 throw new Error("Tried to remove unknown device");
 
             if (newDevices.length === 0)
-                textsecure.storage.removeEncrypted("devices" + number);
+                textsecure.storage.remove("devices" + number);
             else {
                 map.devices = newDevices;
-                textsecure.storage.putEncrypted("devices" + number, map);
+                textsecure.storage.put("devices" + number, map);
             }
         }
     };
@@ -139,7 +139,7 @@
             throw new Error("Tried to store invalid deviceObject");
 
         var number = textsecure.utils.unencodeNumber(deviceObject.encodedNumber)[0];
-        var map = textsecure.storage.getEncrypted("devices" + number);
+        var map = textsecure.storage.get("devices" + number);
 
         if (deviceObject.sessions !== undefined)
             deviceObject.sessions = deviceObject.sessions.serialize()
@@ -170,6 +170,6 @@
                 map.devices.push(deviceObject);
         }
 
-        textsecure.storage.putEncrypted("devices" + number, map);
+        textsecure.storage.put("devices" + number, map);
     };
 })();

--- a/libtextsecure/storage/groups.js
+++ b/libtextsecure/storage/groups.js
@@ -31,7 +31,7 @@
             while (groupId === undefined || textsecure.storage.getEncrypted("group" + groupId) !== undefined)
                 groupId = getString(textsecure.crypto.getRandomBytes(16));
 
-            var me = textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0];
+            var me = textsecure.storage.user.getNumber();
             var haveMe = false;
             var finalNumbers = [];
             for (var i in numbers) {
@@ -69,7 +69,7 @@
             if (group === undefined)
                 return undefined;
 
-            var me = textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0];
+            var me = textsecure.storage.user.getNumber();
             if (number == me)
                 throw new Error("Cannot remove ourselves from a group, leave the group instead");
 

--- a/libtextsecure/storage/groups.js
+++ b/libtextsecure/storage/groups.js
@@ -25,10 +25,10 @@
 
     window.textsecure.storage.groups = {
         createNewGroup: function(numbers, groupId) {
-            if (groupId !== undefined && textsecure.storage.getEncrypted("group" + groupId) !== undefined)
+            if (groupId !== undefined && textsecure.storage.get("group" + groupId) !== undefined)
                 throw new Error("Tried to recreate group");
 
-            while (groupId === undefined || textsecure.storage.getEncrypted("group" + groupId) !== undefined)
+            while (groupId === undefined || textsecure.storage.get("group" + groupId) !== undefined)
                 groupId = getString(textsecure.crypto.getRandomBytes(16));
 
             var me = textsecure.storage.user.getNumber();
@@ -51,13 +51,13 @@
             for (var i in finalNumbers)
                 groupObject.numberRegistrationIds[finalNumbers[i]] = {};
 
-            textsecure.storage.putEncrypted("group" + groupId, groupObject);
+            textsecure.storage.put("group" + groupId, groupObject);
 
             return {id: groupId, numbers: finalNumbers};
         },
 
         getNumbers: function(groupId) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -65,7 +65,7 @@
         },
 
         removeNumber: function(groupId, number) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -77,14 +77,14 @@
             if (i > -1) {
                 group.numbers.slice(i, 1);
                 delete group.numberRegistrationIds[number];
-                textsecure.storage.putEncrypted("group" + groupId, group);
+                textsecure.storage.put("group" + groupId, group);
             }
 
             return group.numbers;
         },
 
         addNumbers: function(groupId, numbers) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -98,16 +98,16 @@
                 }
             }
 
-            textsecure.storage.putEncrypted("group" + groupId, group);
+            textsecure.storage.put("group" + groupId, group);
             return group.numbers;
         },
 
         deleteGroup: function(groupId) {
-            textsecure.storage.removeEncrypted("group" + groupId);
+            textsecure.storage.remove("group" + groupId);
         },
 
         getGroup: function(groupId) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 return undefined;
 
@@ -115,7 +115,7 @@
         },
 
         needUpdateByDeviceRegistrationId: function(groupId, number, encodedNumber, registrationId) {
-            var group = textsecure.storage.getEncrypted("group" + groupId);
+            var group = textsecure.storage.get("group" + groupId);
             if (group === undefined)
                 throw new Error("Unknown group for device registration id");
 
@@ -127,7 +127,7 @@
 
             var needUpdate = group.numberRegistrationIds[number][encodedNumber] !== undefined;
             group.numberRegistrationIds[number][encodedNumber] = registrationId;
-            textsecure.storage.putEncrypted("group" + groupId, group);
+            textsecure.storage.put("group" + groupId, group);
             return needUpdate;
         },
     };

--- a/libtextsecure/storage/user.js
+++ b/libtextsecure/storage/user.js
@@ -25,18 +25,18 @@
 
     window.textsecure.storage.user = {
         setNumberAndDeviceId: function(number, deviceId) {
-            textsecure.storage.putUnencrypted("number_id", number + "." + deviceId);
+            textsecure.storage.put("number_id", number + "." + deviceId);
         },
 
         getNumber: function(key, defaultValue) {
-            var number_id = textsecure.storage.getUnencrypted("number_id");
+            var number_id = textsecure.storage.get("number_id");
             if (number_id === undefined)
                 return undefined;
             return textsecure.utils.unencodeNumber(number_id)[0];
         },
 
         getDeviceId: function(key) {
-            var number_id = textsecure.storage.getUnencrypted("number_id");
+            var number_id = textsecure.storage.get("number_id");
             if (number_id === undefined)
                 return undefined;
             return textsecure.utils.unencodeNumber(number_id)[1];

--- a/libtextsecure/storage/user.js
+++ b/libtextsecure/storage/user.js
@@ -1,0 +1,45 @@
+/* vim: ts=4:sw=4
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+;(function() {
+    /*********************************************
+    *** Utilities to store data about the user ***
+    **********************************************/
+    window.textsecure = window.textsecure || {};
+    window.textsecure.storage = window.textsecure.storage || {};
+
+    window.textsecure.storage.user = {
+        setNumberAndDeviceId: function(number, deviceId) {
+            textsecure.storage.putUnencrypted("number_id", number + "." + deviceId);
+        },
+
+        getNumber: function(key, defaultValue) {
+            var number_id = textsecure.storage.getUnencrypted("number_id");
+            if (number_id === undefined)
+                return undefined;
+            return textsecure.utils.unencodeNumber(number_id)[0];
+        },
+
+        getDeviceId: function(key) {
+            var number_id = textsecure.storage.getUnencrypted("number_id");
+            if (number_id === undefined)
+                return undefined;
+            return textsecure.utils.unencodeNumber(number_id)[1];
+        }
+    };
+})();


### PR DESCRIPTION
This requires reset for a number of reasons.
See individual commits for more information, but essentially this refactors all the storage stuff in libtextsecure so that it is forward-compatible (ie the parts that are still over-complicated can be deleted entirely with no adverse consequences), as well as providing a simple interface which can replace localStorage if its overridden.