### PR TITLE
Remove unsued argument from getDeviceObject

### DIFF
--- a/js/key_worker.js
+++ b/js/key_worker.js
@@ -38162,24 +38162,13 @@ window.axolotl.sessions = {
             textsecure.storage.sessions._removeIdentityKeyForNumber(number);
         },
 
-        getDeviceObject: function(encodedNumber, returnIdentityKey) {
+        getDeviceObject: function(encodedNumber) {
             var number = textsecure.utils.unencodeNumber(encodedNumber)[0];
             var devices = textsecure.storage.devices.getDeviceObjectsForNumber(number);
-            if (devices.length == 0) {
-                if (returnIdentityKey) {
-                    var identityKey = textsecure.storage.devices.getIdentityKeyForNumber(number);
-                    if (identityKey !== undefined)
-                        return {identityKey: identityKey};
-                }
-                return undefined;
-            }
 
             for (var i in devices)
                 if (devices[i].encodedNumber == encodedNumber)
                     return devices[i];
-
-            if (returnIdentityKey)
-                return {identityKey: devices[0].identityKey};
 
             return undefined;
         },

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38161,24 +38161,13 @@ window.axolotl.sessions = {
             textsecure.storage.sessions._removeIdentityKeyForNumber(number);
         },
 
-        getDeviceObject: function(encodedNumber, returnIdentityKey) {
+        getDeviceObject: function(encodedNumber) {
             var number = textsecure.utils.unencodeNumber(encodedNumber)[0];
             var devices = textsecure.storage.devices.getDeviceObjectsForNumber(number);
-            if (devices.length == 0) {
-                if (returnIdentityKey) {
-                    var identityKey = textsecure.storage.devices.getIdentityKeyForNumber(number);
-                    if (identityKey !== undefined)
-                        return {identityKey: identityKey};
-                }
-                return undefined;
-            }
 
             for (var i in devices)
                 if (devices[i].encodedNumber == encodedNumber)
                     return devices[i];
-
-            if (returnIdentityKey)
-                return {identityKey: devices[0].identityKey};
 
             return undefined;
         },

--- a/libtextsecure/storage/devices.js
+++ b/libtextsecure/storage/devices.js
@@ -131,24 +131,13 @@
             textsecure.storage.sessions._removeIdentityKeyForNumber(number);
         },
 
-        getDeviceObject: function(encodedNumber, returnIdentityKey) {
+        getDeviceObject: function(encodedNumber) {
             var number = textsecure.utils.unencodeNumber(encodedNumber)[0];
             var devices = textsecure.storage.devices.getDeviceObjectsForNumber(number);
-            if (devices.length == 0) {
-                if (returnIdentityKey) {
-                    var identityKey = textsecure.storage.devices.getIdentityKeyForNumber(number);
-                    if (identityKey !== undefined)
-                        return {identityKey: identityKey};
-                }
-                return undefined;
-            }
 
             for (var i in devices)
                 if (devices[i].encodedNumber == encodedNumber)
                     return devices[i];
-
-            if (returnIdentityKey)
-                return {identityKey: devices[0].identityKey};
 
             return undefined;
         },


### PR DESCRIPTION
Last usage of the `returnIdentityKey` argument was removed in 8b9a16852.