### PR TITLE
Test for `name` on error object when processing sendMessage errors

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -102,7 +102,7 @@
         }.bind(this)).catch(function(errors) {
             var keyErrors = [];
             _.each(errors, function(e) {
-                if (e.error.name === 'OutgoingIdentityKeyError') {
+                if (_.has(e.error, 'name') && e.error.name === 'OutgoingIdentityKeyError') {
                     keyErrors.push(e.error);
                 }
             });


### PR DESCRIPTION
Was preventing the actual error from bubbling up.