### PR TITLE
Fix for conversation & inbox windows closing callbacks never called.

### DIFF
--- a/js/chromium.js
+++ b/js/chromium.js
@@ -85,14 +85,6 @@
             }
         },
 
-        onClosed: function(callback) {
-            if (chrome.windows) {
-                chrome.windows.onRemoved.addListener(callback);
-            } else if (chrome.app.window) {
-                chrome.app.window.onClosed.addListener(callback);
-            }
-        },
-
         getCurrent: function(callback) {
             if (chrome.windows) {
                 chrome.windows.getCurrent(callback);

--- a/js/panel_controller.js
+++ b/js/panel_controller.js
@@ -133,12 +133,17 @@
                 width: 300,
                 height: 440
             }, function (windowInfo) {
-                windowMap.add({ windowId: windowInfo.id, modelId: modelId });
+                windowId = windowInfo.id;
+                windowMap.add({ windowId: windowId, modelId: modelId });
+
+                windowInfo.onClosed.addListener(function () {
+                    onWindowClosed(windowId);
+                });
 
                 // close the panel if background.html is refreshed
                 extension.windows.beforeUnload(function() {
                     // TODO: reattach after reload instead of closing.
-                    extension.windows.remove(windowInfo.id);
+                    extension.windows.remove(windowId);
                 });
             });
         } else {
@@ -169,10 +174,14 @@
             }, function (windowInfo) {
                 inboxWindowId = windowInfo.id;
 
+                windowInfo.onClosed.addListener(function () {
+                    onWindowClosed(inboxWindowId);
+                });
+
                 // close the panel if background.html is refreshed
                 extension.windows.beforeUnload(function() {
                     // TODO: reattach after reload instead of closing.
-                    extension.windows.remove(windowInfo.id);
+                    extension.windows.remove(inboxWindowId);
                 });
             });
         } else if (inboxOpened === true) {
@@ -196,7 +205,7 @@
     });
 
     // make sure windows are cleaned up on close
-    extension.windows.onClosed(function (windowId) {
+    var onWindowClosed = function (windowId) {
         if (windowMap.windowId[windowId]) {
             closeConversation(windowId);
         }
@@ -205,5 +214,5 @@
             inboxWindowId = 0;
             inboxOpened = false;
         }
-    });
+    };
 })();


### PR DESCRIPTION
As discussed in similar issue there: https://github.com/GoogleChrome/chromedeveditor/issues/1023 - it is not possible to add onClosed event listener on an 'abstract' current window property, it needs to be set on the particular window instance instead.

Before that change, the clean up function was never actually called, because the listener was never properly attached. That was probably the reason of existence for "panel isn't actually open ... and so we try again." code that was executed if the previous window wasn't cleaned up properly (so actually every time). This code is no longer needed, I guess, as the windows are now cleaned up properly.