### PR TITLE
Maintain bottom-most scroll position when resizing conversation area, once again.

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -216,25 +216,21 @@
                 return this.$('.bottom-bar form').submit();
             }
 
-            var $discussionContainer = this.$('.discussion-container'),
-                $bottomBar = this.$('.bottom-bar'),
-                $messageList = this.$('.message-list');
-
-            var scrollPosition = $messageList.scrollTop() + $messageList.outerHeight(),
-                scrollHeight = $messageList[0].scrollHeight,
-                shouldStickToBottom = scrollPosition === scrollHeight;
-
+            this.view.measureScrollPosition();
             window.autosize(this.$messageField);
+
+            var $discussionContainer = this.$('.discussion-container'),
+                $bottomBar = this.$('.bottom-bar');
+
             $bottomBar.outerHeight(this.$messageField.outerHeight() + 1);
             var $bottomBarNewHeight = $bottomBar.outerHeight();
             $discussionContainer.outerHeight(this.$el.outerHeight() - $bottomBarNewHeight - this.$('#header').outerHeight());
 
-            if (shouldStickToBottom) {
-                $messageList.scrollTop(scrollHeight);
-            }
+            this.view.scrollToBottomIfNeeded();
         },
 
         forceUpdateMessageFieldSize: function (event) {
+            this.view.scrollToBottomIfNeeded();
             window.autosize.update(this.$messageField);
             this.updateMessageFieldSize(event);
         }

--- a/js/views/message_list_view.js
+++ b/js/views/message_list_view.js
@@ -27,7 +27,8 @@
         itemView: Whisper.MessageView,
         events: {
             'add': 'scrollToBottom',
-            'update *': 'scrollToBottom'
+            'update *': 'scrollToBottom',
+            'scroll': 'measureScrollPosition'
         },
         measureScrollPosition: function() {
             scrollPosition = this.$el.scrollTop() + this.$el.outerHeight();

--- a/js/views/message_list_view.js
+++ b/js/views/message_list_view.js
@@ -17,6 +17,10 @@
     'use strict';
     window.Whisper = window.Whisper || {};
 
+    var scrollPosition,
+        scrollHeight,
+        shouldStickToBottom;
+
     Whisper.MessageListView = Whisper.ListView.extend({
         tagName: 'ul',
         className: 'message-list',
@@ -25,9 +29,20 @@
             'add': 'scrollToBottom',
             'update *': 'scrollToBottom'
         },
+        measureScrollPosition: function() {
+            scrollPosition = this.$el.scrollTop() + this.$el.outerHeight();
+            scrollHeight = this.el.scrollHeight;
+            shouldStickToBottom = scrollPosition === scrollHeight;
+        },
+        scrollToBottomIfNeeded: function() {
+            if (shouldStickToBottom) {
+                this.$el.scrollTop(scrollHeight);
+            }
+        },
         scrollToBottom: function() {
             // TODO: Avoid scrolling if user has manually scrolled up?
             this.$el.scrollTop(this.el.scrollHeight);
+            this.measureScrollPosition();
         },
         addAll: function() {
             Whisper.ListView.prototype.addAll.apply(this, arguments); // super()


### PR DESCRIPTION
Related with #278. Redone to include keeping scroll at the bottom when resizing the window, as suggested in #305, and to better fit the current code structure.