### PR TITLE
Fix text selection color of outgiong message bubble contents

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -238,12 +238,16 @@
       }
 
       .content {
-        &::selection {
+        a {
+          color: $grey_l;
+        }
+
+        &::selection, a::selection {
           color: $grey_d;
           background: white;
         }
 
-        &::-moz-selection {
+        &::-moz-selection, a::-moz-selection {
           color: $grey_d;
           background: white;
         }

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -236,6 +236,18 @@
         right: -8px;
         border-left: 8px solid $blue;
       }
+
+      .content {
+        &::selection {
+          color: $grey_d;
+          background: white;
+        }
+
+        &::-moz-selection {
+          color: $grey_d;
+          background: white;
+        }
+      }
     }
   }
 

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -662,6 +662,14 @@ input.search {
     .message-list .outgoing .bubble::after {
       right: -8px;
       border-left: 8px solid #2090ea; }
+    .message-detail .outgoing .bubble .content::selection,
+    .message-list .outgoing .bubble .content::selection {
+      color: #454545;
+      background: white; }
+    .message-detail .outgoing .bubble .content::-moz-selection,
+    .message-list .outgoing .bubble .content::-moz-selection {
+      color: #454545;
+      background: white; }
   .message-detail .control .bubble .content,
   .message-list .control .bubble .content {
     font-style: italic; }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -662,12 +662,17 @@ input.search {
     .message-list .outgoing .bubble::after {
       right: -8px;
       border-left: 8px solid #2090ea; }
-    .message-detail .outgoing .bubble .content::selection,
-    .message-list .outgoing .bubble .content::selection {
+    .message-detail .outgoing .bubble .content a,
+    .message-list .outgoing .bubble .content a {
+      color: #f3f3f3; }
+    .message-detail .outgoing .bubble .content::selection, .message-detail .outgoing .bubble .content a::selection,
+    .message-list .outgoing .bubble .content::selection,
+    .message-list .outgoing .bubble .content a::selection {
       color: #454545;
       background: white; }
-    .message-detail .outgoing .bubble .content::-moz-selection,
-    .message-list .outgoing .bubble .content::-moz-selection {
+    .message-detail .outgoing .bubble .content::-moz-selection, .message-detail .outgoing .bubble .content a::-moz-selection,
+    .message-list .outgoing .bubble .content::-moz-selection,
+    .message-list .outgoing .bubble .content a::-moz-selection {
       color: #454545;
       background: white; }
   .message-detail .control .bubble .content,


### PR DESCRIPTION
This will change the text color and the background color of selected
text in outgoing messages to make the selection more noticeable.

EDIT: This will also fix the color of links that have been sent.

::selection and ::-moz-selection have to be seperated into two
selectors because browsers will ignore selectors with partially
unknown syntax.