### PR TITLE
Fix multiple spaces not beeing displayed in message bubbles

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -179,6 +179,8 @@
 
     .content {
       -webkit-user-select: text;
+      white-space: pre-wrap;
+
       a {
         word-break: break-all
       }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -407,7 +407,7 @@ img.emoji {
 
 .conversation-header {
   background: #f3f3f3;
-  border-bottom: solid 1px #d9d9d9; }
+  border-bottom: solid 1px #dadada; }
 
 .menu.conversation-menu {
   float: right;
@@ -624,7 +624,8 @@ input.search {
       border-bottom: 6px solid transparent; }
     .message-detail .bubble .content,
     .message-list .bubble .content {
-      -webkit-user-select: text; }
+      -webkit-user-select: text;
+      white-space: pre-wrap; }
       .message-detail .bubble .content a,
       .message-list .bubble .content a {
         word-break: break-all; }


### PR DESCRIPTION
Multiple spaces ("     ") are displayed by browsers as a single
whitespace character if 'white-space: pre-wrap;' is not set.

Old behaviour:
![before](https://cloud.githubusercontent.com/assets/7175914/9722628/ba823f8c-55b0-11e5-83ec-35f1afb366a4.png)
(missing spaces before "let")


New behaviour:
![after](https://cloud.githubusercontent.com/assets/7175914/9722627/ba61cd60-55b0-11e5-8dc5-dc5068e99a20.png)


