### PR TITLE
Add feature to open image attachments

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -243,7 +243,7 @@
                     var deliveries     = message.get('delivered') || 0;
                     var conversationId = message.get('conversationId');
                     if (conversationId === pushMessage.source || groups.get(conversationId)) {
-                        message.save({delivered: deliveries + 1}).then(
+                        message.save({delivered: deliveries + 1, sent: true}).then(
                             // notify frontend listeners
                             updateConversation.bind(null, conversationId)
                         );

--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -5,7 +5,7 @@
   'use strict';
 
   var ImageView = Backbone.View.extend({
-      tagName: 'img',
+      tagName: 'a',
       events: {
           'load': 'update'
       },
@@ -13,7 +13,11 @@
         this.$el.trigger('update');
       },
       render: function(dataUrl) {
-          this.$el.attr('src', dataUrl);
+          this.$el.attr('href', dataUrl);
+          this.$el.attr('target', '_blank');
+          jQuery('<img/>', {
+            src: dataUrl
+          }).appendTo(this.$el);
           return this;
       }
   });

--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -5,19 +5,19 @@
   'use strict';
 
   var ImageView = Backbone.View.extend({
-      tagName: 'a',
+      tagName: 'img',
       events: {
-          'load': 'update'
+          'load': 'update',
+          'click': 'open'
       },
       update: function() {
         this.$el.trigger('update');
       },
+      open: function () {
+        window.open(this.$el.attr('src'), '_blank');
+      },
       render: function(dataUrl) {
-          this.$el.attr('href', dataUrl);
-          this.$el.attr('target', '_blank');
-          jQuery('<img/>', {
-            src: dataUrl
-          }).appendTo(this.$el);
+          this.$el.attr('src', dataUrl);
           return this;
       }
   });


### PR DESCRIPTION
Images that are attached to messages, either sent or received can be opened in a new tab by clicking on them. The images basically function in the same way as links in the message body.

This is achieved by wrapping sent/received messages in <a> tags with "href" the url of the image.

Resolves: #252